### PR TITLE
Add interactive GorillaTag renderer controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # GTrender
+
+Een kleine web-app om een GorillaTag playermodel te kleuren, poseren en aankleden. Ideaal om snel een render te maken die je direct kunt downloaden. Alle logica draait volledig in de browser met behulp van [three.js](https://threejs.org/), dus je kunt de site eenvoudig hosten op GitHub Pages.
+
+## Features
+
+- RGB-schuiven met waarden van 0 tot 9 (zoals in GorillaTag) inclusief live kleurvoorbeeld en hex-code
+- Meerdere poses die lokaal uit GLB-bestanden geladen worden
+- Cosmetics die je kunt combineren (feesthoed, borst-badge en neon polsbanden)
+- Orbit controls voor de camera en een simpele studiosetting met belichting en vloer
+- Download-knop om de WebGL render direct als PNG op te slaan
+
+## Bestanden
+
+```
+assets/          3D modellen (GLB)
+index.html       Mark-up en script tags
+script.js        Logica voor three.js, UI-koppelingen en cosmetics
+style.css        Styling van de interface
+```
+
+## Lokaal testen
+
+Je hebt geen build-stap nodig. Open `index.html` direct in een moderne browser of gebruik een statische webserver voor live-reloads, bijvoorbeeld:
+
+```bash
+npx serve .
+```
+
+## Deploy naar GitHub Pages
+
+1. Commit en push je wijzigingen naar de `main` branch van deze repository.
+2. Ga in GitHub naar **Settings → Pages**.
+3. Kies als source `Deploy from a branch` en selecteer `main` + de root map (`/`).
+4. Na de build verschijnt je site op `https://<gebruikersnaam>.github.io/GTrender/`.
+
+Veel plezier met het maken van Gorilla renders! 🎉

--- a/index.html
+++ b/index.html
@@ -1,36 +1,65 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>GorillaTag Renderer</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>🦍 GorillaTag Renderer</h1>
+  <main>
+    <header>
+      <h1>🦍 GorillaTag Renderer</h1>
+      <p>Stel je eigen gorilla samen met kleurcodes, poses en cosmetics en download direct een render.</p>
+    </header>
 
-  <div id="controls">
-    <h2>Kleur (RGB 0–9)</h2>
-    <label>R: <input type="range" id="r" min="0" max="9" value="5"></label>
-    <label>G: <input type="range" id="g" min="0" max="9" value="5"></label>
-    <label>B: <input type="range" id="b" min="0" max="9" value="5"></label>
+    <div class="layout">
+      <section id="controls" aria-label="Renderer instellingen">
+        <div class="panel" aria-labelledby="color-heading">
+          <h2 id="color-heading">Kleur (RGB 0–9)</h2>
+          <div class="slider" data-channel="r">
+            <label for="r">Rood</label>
+            <input type="range" id="r" min="0" max="9" value="5" aria-describedby="r-value">
+            <output id="r-value" for="r">5</output>
+          </div>
+          <div class="slider" data-channel="g">
+            <label for="g">Groen</label>
+            <input type="range" id="g" min="0" max="9" value="5" aria-describedby="g-value">
+            <output id="g-value" for="g">5</output>
+          </div>
+          <div class="slider" data-channel="b">
+            <label for="b">Blauw</label>
+            <input type="range" id="b" min="0" max="9" value="5" aria-describedby="b-value">
+            <output id="b-value" for="b">5</output>
+          </div>
+          <div class="color-preview" id="color-preview" role="img" aria-label="Voorbeeld van de geselecteerde kleur"></div>
+          <p id="color-code" class="color-code">RGB (5, 5, 5) • Hex #7F7F7F</p>
+          <button id="random-color" type="button">🎨 Random kleur</button>
+        </div>
 
-    <h2>Pose</h2>
-    <select id="pose">
-      <option value="default">Default</option>
-      <option value="pose2">Pose 2</option>
-    </select>
+        <div class="panel" aria-labelledby="pose-heading">
+          <h2 id="pose-heading">Pose</h2>
+          <select id="pose" aria-label="Selecteer een gorilla pose"></select>
+        </div>
 
-    <h2>Cosmetics</h2>
-    <label><input type="checkbox" id="hat"> Hat</label>
+        <div class="panel" aria-labelledby="cosmetics-heading">
+          <h2 id="cosmetics-heading">Cosmetics</h2>
+          <p class="hint">Combineer accessoires voor jouw unieke look.</p>
+          <div id="cosmetics"></div>
+        </div>
 
-    <button id="download">Download Screenshot</button>
-  </div>
+        <button id="download" type="button" class="primary">⬇️ Download screenshot</button>
+      </section>
 
-  <canvas id="canvas"></canvas>
+      <section class="canvas-wrap" aria-label="3D preview">
+        <canvas id="canvas"></canvas>
+      </section>
+    </div>
+  </main>
 
-  <!-- Laad THREE en GLTFLoader gewoon globaal -->
   <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/loaders/GLTFLoader.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.158.0/examples/js/controls/OrbitControls.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,91 +1,449 @@
-let scene, camera, renderer, gorilla, hat;
+let scene;
+let camera;
+let renderer;
+let controls;
+let gorilla;
+let gorillaMeasurements;
+
+const canvas = document.getElementById("canvas");
+const poseSelect = document.getElementById("pose");
+const cosmeticsContainer = document.getElementById("cosmetics");
+const downloadButton = document.getElementById("download");
+const randomColorButton = document.getElementById("random-color");
+const colorPreview = document.getElementById("color-preview");
+const colorCode = document.getElementById("color-code");
+const outputs = {
+  r: document.getElementById("r-value"),
+  g: document.getElementById("g-value"),
+  b: document.getElementById("b-value"),
+};
+const sliders = {
+  r: document.getElementById("r"),
+  g: document.getElementById("g"),
+  b: document.getElementById("b"),
+};
+
+const loader = new THREE.GLTFLoader();
+const assetCache = new Map();
+const selectedCosmetics = new Set();
+const cosmeticInstances = new Map();
+let currentPoseId = "default";
+let isChangingPose = false;
+
+const POSES = [
+  {
+    id: "default",
+    label: "Default",
+    path: "./assets/gorilla.glb",
+  },
+  {
+    id: "pose2",
+    label: "Power Stance",
+    path: "./assets/pose2.glb",
+  },
+  {
+    id: "lookout",
+    label: "Lookout",
+    path: "./assets/gorilla.glb",
+    tweak(model) {
+      model.rotation.y = THREE.MathUtils.degToRad(-25);
+      model.rotation.z = THREE.MathUtils.degToRad(8);
+      model.position.x += 0.12;
+    },
+  },
+];
+
+const COSMETICS = [
+  {
+    id: "hat",
+    label: "Feesthoed",
+    description: "Een feestelijke hoed voor elke gelegenheid.",
+    type: "gltf",
+    path: "./assets/hat.glb",
+    adjust(instance, measurements) {
+      const wrapper = new THREE.Group();
+      wrapper.add(instance);
+      const hatBox = new THREE.Box3().setFromObject(instance);
+      const hatSize = hatBox.getSize(new THREE.Vector3());
+      const hatCenter = hatBox.getCenter(new THREE.Vector3());
+      instance.position.sub(hatCenter);
+      const targetWidth = measurements.size.x * 0.55;
+      const scaleFactor = hatSize.x > 0 ? targetWidth / hatSize.x : 1;
+      wrapper.scale.setScalar(scaleFactor);
+      const headHeight = measurements.top + (hatSize.y * scaleFactor) * 0.25;
+      wrapper.position.set(measurements.center.x, headHeight, measurements.center.z);
+      return wrapper;
+    },
+  },
+  {
+    id: "badge",
+    label: "Naam Badge",
+    description: "Plaats een badge op de borst van de gorilla.",
+    create(measurements) {
+      const badgeWidth = measurements.size.x * 0.32;
+      const badgeHeight = measurements.size.y * 0.16;
+      const geometry = THREE.RoundedBoxGeometry
+        ? new THREE.RoundedBoxGeometry(badgeWidth, badgeHeight, measurements.size.z * 0.02, 2, 0.02)
+        : new THREE.BoxGeometry(badgeWidth, badgeHeight, measurements.size.z * 0.02);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0xff9356,
+        emissive: 0x331400,
+        roughness: 0.35,
+        metalness: 0.15,
+      });
+      const badge = new THREE.Mesh(geometry, material);
+      badge.position.set(
+        measurements.center.x + measurements.size.x * 0.15,
+        measurements.center.y + measurements.size.y * 0.05,
+        measurements.front + measurements.size.z * 0.05
+      );
+      badge.rotation.y = THREE.MathUtils.degToRad(-8);
+      badge.castShadow = true;
+      badge.receiveShadow = true;
+      return badge;
+    },
+  },
+  {
+    id: "wristbands",
+    label: "Neon Polsbanden",
+    description: "Dubbele neon armbanden voor beide polsen.",
+    create(measurements) {
+      const group = new THREE.Group();
+      const radius = measurements.size.x * 0.18;
+      const tube = measurements.size.x * 0.035;
+      const geometry = new THREE.TorusGeometry(radius, tube, 14, 32);
+      const material = new THREE.MeshStandardMaterial({
+        color: 0x6d9bf7,
+        emissive: 0x0a1639,
+        roughness: 0.25,
+        metalness: 0.4,
+      });
+
+      const left = new THREE.Mesh(geometry, material.clone());
+      const right = new THREE.Mesh(geometry, material.clone());
+
+      const wristHeight = measurements.center.y - measurements.size.y * 0.2;
+      left.position.set(measurements.left - radius * 0.15, wristHeight, measurements.center.z + radius * 0.6);
+      right.position.set(measurements.right + radius * 0.15, wristHeight, measurements.center.z - radius * 0.6);
+
+      left.rotation.x = THREE.MathUtils.degToRad(65);
+      right.rotation.x = THREE.MathUtils.degToRad(115);
+
+      [left, right].forEach((mesh) => {
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        group.add(mesh);
+      });
+
+      return group;
+    },
+  },
+];
+
+const POSE_MAP = new Map(POSES.map((pose) => [pose.id, pose]));
+const COSMETIC_MAP = new Map(COSMETICS.map((cosmetic) => [cosmetic.id, cosmetic]));
 
 init();
+setupUI();
+loadPose(currentPoseId);
 animate();
 
 function init() {
   scene = new THREE.Scene();
-  camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-  camera.position.z = 3;
+  scene.background = new THREE.Color(0x06070d);
+  scene.fog = new THREE.Fog(0x06070d, 8, 18);
 
-  renderer = new THREE.WebGLRenderer({ canvas: document.getElementById("canvas"), antialias: true });
-  renderer.setSize(window.innerWidth * 0.8, window.innerHeight * 0.6);
+  camera = new THREE.PerspectiveCamera(50, getAspect(), 0.1, 100);
+  camera.position.set(1.8, 1.55, 2.8);
 
-  const light = new THREE.DirectionalLight(0xffffff, 1);
-  light.position.set(5, 5, 5);
-  scene.add(light);
-  scene.add(new THREE.AmbientLight(0x404040));
+  renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    preserveDrawingBuffer: true,
+  });
+  renderer.outputColorSpace = THREE.SRGBColorSpace;
+  renderer.setPixelRatio(window.devicePixelRatio);
+  resizeRenderer();
+  renderer.shadowMap.enabled = true;
+  renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 
-  // Gorilla model
-  const loader = new THREE.GLTFLoader();
-  loader.load("./assets/gorilla.glb", (gltf) => {
-    gorilla = gltf.scene;
-    scene.add(gorilla);
+  controls = new THREE.OrbitControls(camera, renderer.domElement);
+  controls.target.set(0, 1, 0);
+  controls.enableDamping = true;
+  controls.dampingFactor = 0.08;
+  controls.minDistance = 1.2;
+  controls.maxDistance = 6;
+  controls.maxPolarAngle = Math.PI / 1.75;
+
+  const ambient = new THREE.HemisphereLight(0xe8efff, 0x0d0f16, 0.55);
+  scene.add(ambient);
+
+  const keyLight = new THREE.DirectionalLight(0xffffff, 1.2);
+  keyLight.position.set(2.5, 4.5, 3.4);
+  keyLight.castShadow = true;
+  keyLight.shadow.radius = 6;
+  keyLight.shadow.mapSize.set(1024, 1024);
+  scene.add(keyLight);
+
+  const rimLight = new THREE.DirectionalLight(0x6d9bf7, 0.8);
+  rimLight.position.set(-3.2, 3.2, -2.5);
+  scene.add(rimLight);
+
+  const floor = new THREE.Mesh(
+    new THREE.CylinderGeometry(2.8, 2.8, 0.05, 64),
+    new THREE.MeshStandardMaterial({
+      color: 0x1a1c2c,
+      roughness: 0.85,
+      metalness: 0.1,
+    })
+  );
+  floor.receiveShadow = true;
+  floor.position.y = -0.02;
+  scene.add(floor);
+
+  window.addEventListener("resize", resizeRenderer);
+}
+
+function setupUI() {
+  POSES.forEach((pose) => {
+    const option = document.createElement("option");
+    option.value = pose.id;
+    option.textContent = pose.label;
+    poseSelect.appendChild(option);
+  });
+
+  poseSelect.value = currentPoseId;
+  poseSelect.addEventListener("change", async (event) => {
+    if (event.target.value === currentPoseId || isChangingPose) return;
+    currentPoseId = event.target.value;
+    await loadPose(currentPoseId);
+  });
+
+  COSMETICS.forEach((cosmetic) => {
+    const label = document.createElement("label");
+    label.className = "cosmetic";
+
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.value = cosmetic.id;
+    checkbox.addEventListener("change", () => {
+      if (checkbox.checked) {
+        selectedCosmetics.add(cosmetic.id);
+      } else {
+        selectedCosmetics.delete(cosmetic.id);
+      }
+      refreshCosmetics();
+    });
+
+    const text = document.createElement("div");
+    text.className = "cosmetic-text";
+    const title = document.createElement("span");
+    title.textContent = cosmetic.label;
+    const description = document.createElement("small");
+    description.textContent = cosmetic.description;
+    text.append(title, description);
+
+    label.append(checkbox, text);
+    cosmeticsContainer.appendChild(label);
+  });
+
+  Object.entries(sliders).forEach(([channel, input]) => {
+    input.addEventListener("input", () => updateColor(channel));
+    outputs[channel].textContent = input.value;
+  });
+
+  randomColorButton.addEventListener("click", () => {
+    Object.values(sliders).forEach((input) => {
+      const randomValue = Math.floor(Math.random() * 10);
+      input.value = randomValue.toString();
+    });
     updateColor();
   });
 
-  document.getElementById("r").addEventListener("input", updateColor);
-  document.getElementById("g").addEventListener("input", updateColor);
-  document.getElementById("b").addEventListener("input", updateColor);
+  downloadButton.addEventListener("click", downloadImage);
 
-  document.getElementById("pose").addEventListener("change", changePose);
-  document.getElementById("hat").addEventListener("change", toggleHat);
-  document.getElementById("download").addEventListener("click", downloadImage);
+  updateColor();
 }
 
-function updateColor() {
-  if (!gorilla) return;
-  let r = document.getElementById("r").value * 28;
-  let g = document.getElementById("g").value * 28;
-  let b = document.getElementById("b").value * 28;
-  gorilla.traverse((child) => {
-    if (child.isMesh) {
-      child.material.color.setRGB(r / 255, g / 255, b / 255);
+async function loadPose(poseId) {
+  const pose = POSE_MAP.get(poseId) ?? POSE_MAP.get("default");
+  if (!pose) return;
+  isChangingPose = true;
+
+  if (gorilla) {
+    scene.remove(gorilla);
+    gorilla = undefined;
+    gorillaMeasurements = undefined;
+  }
+
+  try {
+    const template = await loadGLTF(pose.path);
+    const model = template.clone(true);
+    prepareModel(model);
+    if (pose.tweak) {
+      pose.tweak(model);
     }
-  });
-}
-
-function changePose(e) {
-  const loader = new THREE.GLTFLoader();
-  if (gorilla) scene.remove(gorilla);
-
-  if (e.target.value === "pose2") {
-    loader.load("./assets/pose2.glb", (gltf) => {
-      gorilla = gltf.scene;
-      scene.add(gorilla);
-      updateColor();
-    });
-  } else {
-    loader.load("./assets/gorilla.glb", (gltf) => {
-      gorilla = gltf.scene;
-      scene.add(gorilla);
-      updateColor();
-    });
+    gorilla = model;
+    scene.add(gorilla);
+    gorillaMeasurements = measureModel(gorilla);
+    updateColor();
+    await refreshCosmetics();
+  } catch (error) {
+    console.error("Kon pose niet laden", error);
+  } finally {
+    isChangingPose = false;
   }
 }
 
-function toggleHat(e) {
-  const loader = new THREE.GLTFLoader();
-  if (e.target.checked) {
-    loader.load("./assets/hat.glb", (gltf) => {
-      hat = gltf.scene;
-      scene.add(hat);
-    });
-  } else if (hat) {
-    scene.remove(hat);
-    hat = null;
+function prepareModel(model) {
+  model.traverse((child) => {
+    if (child.isMesh) {
+      child.material = child.material.clone();
+      child.castShadow = true;
+      child.receiveShadow = true;
+    }
+  });
+
+  const box = new THREE.Box3().setFromObject(model);
+  const center = box.getCenter(new THREE.Vector3());
+  model.position.x -= center.x;
+  model.position.z -= center.z;
+  model.position.y -= box.min.y;
+}
+
+function measureModel(model) {
+  const box = new THREE.Box3().setFromObject(model);
+  const size = box.getSize(new THREE.Vector3());
+  const center = box.getCenter(new THREE.Vector3());
+  return {
+    box,
+    size,
+    center,
+    top: box.max.y,
+    bottom: box.min.y,
+    front: box.max.z,
+    back: box.min.z,
+    left: box.min.x,
+    right: box.max.x,
+  };
+}
+
+function updateColor(changedChannel) {
+  Object.entries(sliders).forEach(([channel, input]) => {
+    if (!changedChannel || changedChannel === channel) {
+      outputs[channel].textContent = input.value;
+    }
+  });
+
+  const rSteps = Number(sliders.r.value);
+  const gSteps = Number(sliders.g.value);
+  const bSteps = Number(sliders.b.value);
+
+  const to255 = (value) => Math.round((value / 9) * 255);
+  const r = to255(rSteps);
+  const g = to255(gSteps);
+  const b = to255(bSteps);
+
+  const color = new THREE.Color(`rgb(${r}, ${g}, ${b})`);
+
+  colorPreview.style.background = `rgb(${r}, ${g}, ${b})`;
+  const hex = `#${color.getHexString().toUpperCase()}`;
+  colorCode.textContent = `RGB (${rSteps}, ${gSteps}, ${bSteps}) • Hex ${hex}`;
+
+  if (!gorilla) return;
+
+  gorilla.traverse((child) => {
+    if (child.isMesh && child.material && child.material.color) {
+      child.material.color.copy(color);
+      if (child.material.emissive) {
+        child.material.emissive.setRGB(color.r * 0.1, color.g * 0.1, color.b * 0.1);
+      }
+    }
+  });
+
+}
+
+async function refreshCosmetics() {
+  if (!gorilla || !gorillaMeasurements) return;
+
+  cosmeticInstances.forEach((object) => {
+    gorilla.remove(object);
+  });
+  cosmeticInstances.clear();
+
+  for (const id of selectedCosmetics) {
+    const cosmetic = COSMETIC_MAP.get(id);
+    if (!cosmetic) continue;
+
+    let instance;
+    if (cosmetic.type === "gltf") {
+      instance = (await loadGLTF(cosmetic.path)).clone(true);
+      instance.traverse((child) => {
+        if (child.isMesh) {
+          child.material = child.material.clone();
+          child.castShadow = true;
+          child.receiveShadow = true;
+        }
+      });
+    } else if (typeof cosmetic.create === "function") {
+      instance = cosmetic.create(gorillaMeasurements);
+    }
+
+    if (!instance) continue;
+
+    let finalInstance = instance;
+    if (typeof cosmetic.adjust === "function") {
+      const adjusted = cosmetic.adjust(instance, gorillaMeasurements);
+      if (adjusted instanceof THREE.Object3D) {
+        finalInstance = adjusted;
+      }
+    }
+
+    gorilla.add(finalInstance);
+    cosmeticInstances.set(id, finalInstance);
   }
 }
 
 function downloadImage() {
   const link = document.createElement("a");
-  link.download = "gorillatag.png";
+  link.download = `gorillatag-${Date.now()}.png`;
   link.href = renderer.domElement.toDataURL("image/png");
   link.click();
 }
 
 function animate() {
   requestAnimationFrame(animate);
-  if (gorilla) gorilla.rotation.y += 0.01;
+  if (gorilla && !isChangingPose) {
+    gorilla.rotation.y += 0.0035;
+  }
+  controls.update();
   renderer.render(scene, camera);
+}
+
+function getAspect() {
+  const { clientWidth, clientHeight } = canvas.parentElement;
+  return clientWidth / clientHeight;
+}
+
+function resizeRenderer() {
+  const { clientWidth, clientHeight } = canvas.parentElement;
+  renderer.setSize(clientWidth, clientHeight, false);
+  camera.aspect = clientWidth / clientHeight;
+  camera.updateProjectionMatrix();
+}
+
+function loadGLTF(path) {
+  if (!assetCache.has(path)) {
+    const promise = new Promise((resolve, reject) => {
+      loader.load(
+        path,
+        (gltf) => resolve(gltf.scene),
+        undefined,
+        (error) => reject(error)
+      );
+    });
+    assetCache.set(path, promise);
+  }
+  return assetCache.get(path);
 }

--- a/style.css
+++ b/style.css
@@ -1,22 +1,247 @@
+:root {
+  color-scheme: dark;
+  font-family: "Segoe UI", "Helvetica Neue", system-ui, sans-serif;
+  --panel-bg: rgba(24, 26, 36, 0.92);
+  --panel-border: rgba(255, 255, 255, 0.06);
+  --accent: #ff6b6b;
+  --accent-strong: #ff9356;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: sans-serif;
-  background: #111;
-  color: #fff;
+  min-height: 100vh;
+  background: radial-gradient(circle at top, #1c2236 0%, #090a0f 60%, #050608 100%);
+  color: #f3f5ff;
   display: flex;
-  flex-direction: column;
-  align-items: center;
+  justify-content: center;
+}
+
+main {
+  width: min(1200px, 100%);
+  padding: 24px clamp(16px, 4vw, 40px) 48px;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+}
+
+header p {
+  margin: 0;
+  color: rgba(243, 245, 255, 0.75);
+}
+
+.layout {
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(16px, 3vw, 28px);
 }
 
 #controls {
-  margin: 20px;
-  background: #222;
-  padding: 15px;
-  border-radius: 10px;
+  flex: 1 1 320px;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 2vw, 18px);
+}
+
+.canvas-wrap {
+  flex: 2 1 480px;
+  background: rgba(8, 10, 16, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 18px;
+  padding: clamp(12px, 2vw, 18px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 420px;
+  position: relative;
+  overflow: hidden;
+}
+
+.canvas-wrap::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 107, 107, 0.25), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(109, 155, 247, 0.2), transparent 55%);
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
 canvas {
-  width: 80vw;
-  height: 60vh;
-  border: 1px solid #444;
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  display: block;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.35);
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 16px;
+  padding: clamp(14px, 2.2vw, 20px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  backdrop-filter: blur(12px);
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.slider {
+  display: grid;
+  grid-template-columns: 1fr minmax(120px, 2fr) minmax(32px, max-content);
+  align-items: center;
+  gap: 12px;
+  padding: 6px 0;
+}
+
+.slider label {
+  font-weight: 600;
+}
+
+input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+output {
+  min-width: 36px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.color-preview {
+  width: 100%;
+  height: 56px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.45);
+}
+
+.color-code {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(243, 245, 255, 0.7);
+}
+
+button,
+select {
+  font: inherit;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(18, 19, 28, 0.8);
+  color: inherit;
+  padding: 10px 14px;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+}
+
+button:hover,
+select:hover,
+button:focus-visible,
+select:focus-visible {
+  border-color: rgba(255, 147, 86, 0.6);
+  box-shadow: 0 4px 16px rgba(255, 107, 107, 0.2);
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  border: none;
+  color: #0b0c12;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+#cosmetics {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cosmetic {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  background: rgba(12, 14, 22, 0.6);
+}
+
+.cosmetic input[type="checkbox"] {
+  margin: 0;
+  accent-color: var(--accent);
+}
+
+.cosmetic-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.cosmetic-text span {
+  font-weight: 600;
+}
+
+.cosmetic-text small {
+  font-size: 0.78rem;
+  color: rgba(243, 245, 255, 0.55);
+}
+
+.hint {
+  margin: -4px 0 4px;
+  font-size: 0.85rem;
+  color: rgba(243, 245, 255, 0.55);
+}
+
+@media (max-width: 960px) {
+  .layout {
+    flex-direction: column;
+  }
+
+  .canvas-wrap {
+    min-height: 360px;
+  }
+}
+
+@media (max-width: 540px) {
+  .slider {
+    grid-template-columns: 1fr;
+    grid-template-areas: "label" "range" "value";
+    gap: 8px;
+  }
+
+  .slider label {
+    grid-area: label;
+  }
+
+  .slider input {
+    grid-area: range;
+  }
+
+  .slider output {
+    grid-area: value;
+    text-align: left;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the landing page with dedicated panels for RGB sliders, pose selection, cosmetics and download controls
- expand the Three.js bootstrap to support multiple poses, toggleable cosmetics, orbit controls and accurate colour previews
- refresh the styling and README with hosting instructions and feature highlights

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d0254a0f548329a03adffe29c074eb